### PR TITLE
Update theme name in SCSS pages for _s theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,10 +189,8 @@ Generator.prototype.convertFiles = function convertFiles() {
             fs.open(newName, 'w', '0666', function() {
               fs.readFile(pathFile, 'utf8', function (err, data) {
                 if (err) throw err;
-                // If using default _s theme, insert the given theme name into SCSS files
-                if (self.themeBoilerplate == 'https://github.com/automattic/_s/tarball/master') {
-                  data = data.replace('Theme Name: _s', 'Theme Name: ' + self.themeNameOriginal);
-                }
+                // Insert the given theme name into SCSS files
+                data = data.replace(/^.*Theme Name:.*$/mg, 'Theme Name: ' + self.themeNameOriginal);
                 fs.writeFile(newName, data);
               });
             });

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ Generator.prototype.askFor = function askFor(arguments) {
     if(e) { return self.emit('error', e); }
 
     // set the property to parse the gruntfile
+    self.themeNameOriginal = props.themeName;
     self.themeName = props.themeName.replace(/\ /g, '').toLowerCase();
     self.themeBoilerplate = props.themeBoilerplate;
     self.wordpressVersion = props.wordpressVersion;
@@ -186,8 +187,12 @@ Generator.prototype.convertFiles = function convertFiles() {
             // to avoid deleting style.css which is needed to activate the them,
             // we do not rename but only create another file then copy the content
             fs.open(newName, 'w', '0666', function() {
-              fs.readFile(pathFile, function (err, data) {
+              fs.readFile(pathFile, 'utf8', function (err, data) {
                 if (err) throw err;
+                // If using default _s theme, insert the given theme name into SCSS files
+                if (self.themeBoilerplate == 'https://github.com/automattic/_s/tarball/master') {
+                  data = data.replace('Theme Name: _s', 'Theme Name: ' + self.themeNameOriginal);
+                }
                 fs.writeFile(newName, data);
               });
             });


### PR DESCRIPTION
I hope you don't mind that I continued to play around with this. 

I added a small feature where, if the user is using the default starter theme, _s, then the
theme name is updated in all of the SCSS files. Right now the CSS files remain unchanged. 
