### PR TITLE
Modified link to  WordPress-Plugin-Boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ### Plugin
 
-  `$ yo yo-wordpress:plugin` - Generates a plugin with [WordPress Plugin Boilerplate](https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/tree/master/plugin-boilerplate).
+  `$ yo yo-wordpress:plugin` - Generates a plugin with [WordPress Plugin Boilerplate](https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate).
 
 ## Configuration
 


### PR DESCRIPTION
Hi Romain Berger,

I modified the README.md file to link to correct  WordPress-Plugin-Boilerplate page.

Thank you
