### PR TITLE
Add `yo` as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
     "rimraf": "~2.1.4",
     "semver": "~2.0.10"
   },
+  "peerDependencies": {
+    "yo": ">=1.0.0-rc.1.1"
+  },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.8.0",
+    "npm": ">=1.2.10"
   },
   "keywords": [
     "yeoman",


### PR DESCRIPTION
By adding `yo` as peer dependency, the user only has to `npm install -g generator-yo-wordpress` and is good to go. We're currently in process of adding this to all official generators, so we can adjust the documentation accordingly.

https://github.com/yeoman/generator/issues/305

_Edit_

I also added `npm >= 1.2.10` as engine requirement which shows a non-fatal warning in case the user is using an earlier version of npm, which doesn't support peer dependencies.
