### PR TITLE
Hotfix for ( #31 )

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -58,10 +58,16 @@ Generator.prototype.getVersion = function getVersion() {
                     else {
                       var pattern = /\d\.\d[\.\d]*/ig
                         , match = pattern.exec(stdout)
+                        , patternShort = /^\d\.\d$/
+                        , semverLatestString = match[0]
+                        , semverVersionString = self.latestVersion
+                        
+                      if (semverLatestString.match(patternShort)) semverLatestString += '.0'
+                      if (semverVersionString.match(patternShort)) semverVersionString += '.0'
 
                       if (match !== null && typeof match[0] !== 'undefined' && match[0] !== 'undefined') {
                         // update config if needed
-                        if (semver.gt(match[0], self.latestVersion)) {
+                        if (semver.gt(semverLatestString, semverVersionString)) {
                           self.log.writeln('Updating config with latest version: '+match[0])
                           config.updateWordpressVersion(match[0])
                         }


### PR DESCRIPTION
Created 2 temp variables that check for the third part of the version number and add `.0` if it's missing, then use those for semver comparison.
